### PR TITLE
Update docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,7 +23,6 @@ services:
       SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/cascade
       SPRING_DATASOURCE_USERNAME: cascade
       SPRING_DATASOURCE_PASSWORD_FILE: /run/secrets/db_password
-      CUSTOM_CONTAINER_MODE_ENABLED: true
     volumes:
       - app-data:/app/storage
     ports:


### PR DESCRIPTION
No more need to set the variable CUSTOM_CONTAINER_MODE_ENABLED to true it is done in the image

Possible to set it to false in the docker compose if needed (no current use case)
      CUSTOM_CONTAINER_MODE_ENABLED: false